### PR TITLE
Uses antialiased resize functions

### DIFF
--- a/accimage.h
+++ b/accimage.h
@@ -15,8 +15,9 @@ typedef struct {
 } ImageObject;
 
 void image_copy_deinterleave(ImageObject* self, unsigned char* output_buffer);
+void image_copy_deinterleave_float(ImageObject* self, float* output_buffer);
 void image_from_jpeg(ImageObject* self, const char* path);
-void image_resize(ImageObject* self, int new_height, int new_width);
+void image_resize(ImageObject* self, int new_height, int new_width, int antialiasing);
 void image_flip_left_right(ImageObject* self);
 
 #endif


### PR DESCRIPTION
These match the PIL (pillow) bilinear interpolation more closely than
without antialiasing. The performance difference is pretty small (.30
seconds per mini-batch vs .29 seconds).

Also adds a conversion from the internal representation to floating
point (0.0 - 1.0). This makes the calling code in torchvision slightly
faster.