### PR TITLE
Implements in-memory loading of images

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ accimage mimics the PIL API and can be used as a backend for
 
 Operations implemented:
 
+- `Image(path)` - creates an `accimage.Image` from a path to a jpeg file
+   - For example: `img = accimage.Image('chicago.jpg')`
+- `Image(bytes)` - creates an `accimage.Image` from the bytes of a jpeg file loaded into memory
+   - For example: `f = open('chicago.jpg', 'rb'); b = f.read(); img = accimage.Image(b)`
 - `Image.resize((width, height))`
 - `Image.crop((left, upper, right, lower))`
 - `Image.transpose(PIL.Image.FLIP_LEFT_RIGHT)`

--- a/accimage.h
+++ b/accimage.h
@@ -16,7 +16,8 @@ typedef struct {
 
 void image_copy_deinterleave(ImageObject* self, unsigned char* output_buffer);
 void image_copy_deinterleave_float(ImageObject* self, float* output_buffer);
-void image_from_jpeg(ImageObject* self, const char* path);
+void image_from_jpeg_path(ImageObject* self, const char* path);
+void image_from_jpeg_memory(ImageObject* self, const char* inmem, unsigned long inmem_size);
 void image_resize(ImageObject* self, int new_height, int new_width, int antialiasing);
 void image_flip_left_right(ImageObject* self);
 

--- a/test.py
+++ b/test.py
@@ -31,6 +31,20 @@ def test_reading_image():
     assert image.width == 1920
     assert image.height == 931
 
+def test_reading_image_from_memory():
+    def get_img(inp):
+        image = accimage.Image(inp)
+        image_np = np.empty([image.channels, image.height, image.width], dtype=np.uint8)
+        image.copyto(image_np)
+        return image_np
+
+    path = 'chicago.jpg'
+    with open(path, 'rb') as f:
+        imbytes = f.read()
+
+    bytes_img = get_img(imbytes)
+    path_img = get_img(path)
+    assert np.alltrue(np.equal(bytes_img, path_img))
 
 def test_resizing():
     image = accimage.Image("chicago.jpg")


### PR DESCRIPTION
The following now works:

```
with open('chicago.jpg', 'rb') as f:
   img_bytes = f.read()
img = accimage.Image(img_bytes)
```

Fixes #2 cc: @vadimkantorov